### PR TITLE
Header pairs delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-headers",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "https://github.com/improbable-eng/js-browser-headers",

--- a/src/BrowserHeaders.ts
+++ b/src/BrowserHeaders.ts
@@ -79,10 +79,10 @@ export class BrowserHeaders {
     const pairs = str.split("\r\n");
     for (let i = 0; i < pairs.length; i++) {
       const p = pairs[i];
-      const index = p.indexOf(": ");
+      const index = p.indexOf(":");
       if (index > 0) {
-        const key = p.substring(0, index);
-        const value = p.substring(index + 2);
+        const key = p.substring(0, index).trim();
+        const value = p.substring(index + 1).trim();
         this.append(key, value);
       }
     }


### PR DESCRIPTION
**appendFromString** method is used to parse response Trailers in grpc-web-client.

However, non all GRPC proxies delimit trailer name/value pair with ": ".

For example [Envoy grpc-web filter ](https://envoyproxy.github.io/envoy/configuration/http_filters/grpc_web_filter.html) delimits them just with ":" without space.  And thus grpc-web-client can't get grpc status from response.