### PR TITLE
toHeaders returns browser's Headers class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-headers",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "https://github.com/improbable-eng/js-browser-headers",

--- a/src/BrowserHeaders.ts
+++ b/src/BrowserHeaders.ts
@@ -1,5 +1,4 @@
 import { normalizeName, normalizeValue, getHeaderValues, getHeaderKeys, splitHeaderValue } from "./util";
-import { WindowHeaders } from "./WindowHeaders";
 
 export interface Map<K, V> {
   clear(): void;
@@ -37,9 +36,9 @@ export class BrowserHeaders {
 
     if (init) {
       if (typeof Headers !== "undefined" && init instanceof Headers) {
-        const keys = getHeaderKeys(init as WindowHeaders);
+        const keys = getHeaderKeys(init as Headers);
         keys.forEach(key => {
-          const values = getHeaderValues(init as WindowHeaders, key);
+          const values = getHeaderValues(init as Headers, key);
           values.forEach(value => {
             if (options.splitValues) {
               this.append(key, splitHeaderValue(value));
@@ -166,9 +165,9 @@ export class BrowserHeaders {
       }, this);
   }
   
-  toHeaders(): WindowHeaders {
+  toHeaders(): Headers {
     if (typeof Headers !== "undefined") {
-      const headers: WindowHeaders = new Headers();
+      const headers = new Headers();
       this.forEach((key, values) => {
         values.forEach(value => {
           headers.append(key, value);
@@ -184,5 +183,5 @@ export class BrowserHeaders {
 export namespace BrowserHeaders {
   export type HeaderObject = {[key: string]: string|string[]};
   export type HeaderMap = Map<string, string|string[]>;
-  export type ConstructorArg = HeaderObject | HeaderMap | BrowserHeaders | WindowHeaders | string;
+  export type ConstructorArg = HeaderObject | HeaderMap | BrowserHeaders | Headers | string;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,8 @@ export function normalizeValue(value: any): string {
 
 // getHeadersValues abstracts the difference between get() and getAll() between browsers and always returns an array
 /** @internal */
-export function getHeaderValues(headers: WindowHeaders, key: string): string[] {
+export function getHeaderValues(headersAsNative: Headers, key: string): string[] {
+  const headers =  toWindowHeaders(headersAsNative);
   if (headers instanceof Headers && headers.getAll) {
     // If the headers instance has a getAll function then it will return an array
     return headers.getAll(key);
@@ -40,9 +41,15 @@ export function getHeaderValues(headers: WindowHeaders, key: string): string[] {
   return getValue;
 }
 
+// toWindowHeaders casts the native browser class to an interface that includes functions of different browser implementations
+function toWindowHeaders(headersAsNative: Headers): WindowHeaders {
+  return headersAsNative as any as WindowHeaders;
+}
+
 // getHeaderKeys returns an array of keys in a headers instance
 /** @internal */
-export function getHeaderKeys(headers: WindowHeaders): string[] {
+export function getHeaderKeys(headersAsNative: Headers): string[] {
+  const headers =  toWindowHeaders(headersAsNative);
   const asMap: {[key: string]: boolean} = {};
   const keys: string[] = [];
 

--- a/test/BrowserHeaders.spec.ts
+++ b/test/BrowserHeaders.spec.ts
@@ -275,6 +275,18 @@ describe("browser-headers", () => {
           ok(keyAString === "one, Two" || keyAString === "one,Two");
           deepEqual(getHeaderValues(headers, "keyB"), ["three"]);
         });
+
+        it("should be compatible with fetch", () => {
+          const browserHeaders = new BrowserHeaders({
+            "keyA": ["one", "Two"],
+            "keyB": "three"
+          });
+          const headers = browserHeaders.toHeaders();
+          const promise = fetch("http://127.0.0.1", {
+            headers: headers,
+          });
+          ok(promise, "promise is returned");
+        });
       });
     });
   }


### PR DESCRIPTION
Returning the browser's own `Headers` class from `toHeaders` should avoid any issues when using this package with `fetch`.