### PR TITLE
fix(util): Explicitly check for undefined value in getHeaderValues

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -33,8 +33,11 @@ export function getHeaderValues(headersAsNative: Headers, key: string): string[]
   }
 
   // There is no getAll() function so get *should* return an array
-  const getValue = headers.get(key);
-  if (getValue && typeof getValue === "string") {
+  if (!headers.has(key)) {
+    return [];
+  }
+  const getValue = headers.get(key) as string[] | string;
+  if (typeof getValue === "string") {
     // some .get() implementations return a string even though they don't have a .getAll() - notably Microsoft Edge
     return [getValue];
   }


### PR DESCRIPTION
Fix for https://github.com/improbable-eng/grpc-web/issues/1109

getHeaderValues does a truthy check with the value that is returned by headers.get 

```
  const getValue = headers.get(key);
  if (getValue && typeof getValue === "string") {
```

If getValue is an empty string, it fails this check. The empty string is returned by the function and the logic throws an error when .forEach is done on it. Fix is to correctly verify for non existence of the value and return an empty array in that case

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
Updated getHeaderValue to first check for the existence using headers.has. If the value does not exist, return empty array.  Removed the truthy check afterwords

## Verification

Tested by creating a build, using that build in @improbable/grpc-web client and further using that. The issue https://github.com/improbable-eng/grpc-web/issues/1109 goes away
<!-- How you tested it? How do you know it works? -->
